### PR TITLE
Broadcast event on playback progress

### DIFF
--- a/src/directives/ion-audio-track.js
+++ b/src/directives/ion-audio-track.js
@@ -42,6 +42,7 @@ function ionAudioTrack(MediaManager, $rootScope) {
             $scope.track.status = status;
         };
         var progressChange = function(progress, duration) {
+            $rootScope.$broadcast('ionic-audio:progressChange', [progress, duration]);
             $scope.track.progress = progress;
             $scope.track.duration = duration;
         };


### PR DESCRIPTION
This change let developer listen to 'progress' events from controller, to synchronize operations with audio playback.

I did not notice performance hits on preliminary tests.
